### PR TITLE
:bug: Change outdated function from ``mnt.pyfiction``

### DIFF
--- a/src/mnt/opdom_explorer/gui/widgets/plot_operational_domain_widget.py
+++ b/src/mnt/opdom_explorer/gui/widgets/plot_operational_domain_widget.py
@@ -413,7 +413,7 @@ class PlotOperationalDomainWidget(QWidget):
             )
             return
 
-        gs = pyfiction.determine_groundstate_from_simulation_results(sim_result)[0]
+        gs = pyfiction.groundstate_from_simulation_result(sim_result)[0]
 
         # Determine operational status
         status = pyfiction.operational_status.NON_OPERATIONAL


### PR DESCRIPTION
## Description

The function name of ``determine_groundstate_from_simulation_results`` has been changed to ``groundstate_from_simulation_result`` in _pyfiction_. This PR fixes this deprecated piece of code.



## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [ ] I have created/adjusted the Python bindings for any new or updated functionality.
- [x] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
