### PR TITLE
:bug: Fix wrong label if positive SiDBs occur.

### DIFF
--- a/src/mnt/opdom_explorer/gui/widgets/plot_operational_domain_widget.py
+++ b/src/mnt/opdom_explorer/gui/widgets/plot_operational_domain_widget.py
@@ -349,7 +349,7 @@ class PlotOperationalDomainWidget(QWidget):
         # Perform Positive Charges Check in the Main Thread
         self.positive_charges_possible = pyfiction.can_positive_charges_occur(self.lyt, self.qe_sim_params)
 
-        if self.positive_charges_possible and self.lyt.num_cells() > 15:
+        if self.positive_charges_possible:
             # Display a QMessageBox with OK and Back buttons
             msg_box = QMessageBox(self)
             msg_box.setWindowTitle("Positive Charges May Occur")


### PR DESCRIPTION
## Description

This PR fixes #74. As soon as a positive charge occurs, the gate has to be labeled as non-operational. This should now be fixed.  


## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [ ] I have added appropriate tests and documentation.
- [ ] I have added a changelog entry.
- [ ] I have created/adjusted the Python bindings for any new or updated functionality.
- [ ] I have made sure that all CI jobs on GitHub pass.
- [ ] The pull request introduces no new warnings and follows the project's style guidelines.
